### PR TITLE
Removing the duplicate badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![All Contributors](https://img.shields.io/github/all-contributors/nsunami/dmp-helper?color=ee8449&style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # DMP Helper


### PR DESCRIPTION
This PR removes the duplicate badge from README for the all-contributors bot.

Fixes #9 